### PR TITLE
event pane: make host and service configurable links

### DIFF
--- a/example/config.rb
+++ b/example/config.rb
@@ -18,5 +18,13 @@ config.store[:public] = "#{riemann_src}/public"
 
 # Save workspace configuration to Amazon S3 (you'll need to have the "fog"
 # gem installed)
+#
 # config.store[:ws_config] = 's3://my-bucket/config.json'
 # config.store[:s3_config] = {:aws_access_key_id => "123ABC", :aws_secret_access_key => "789XYZ"}
+
+# URLs of the links of the "host" and "service" fields, in the event pane (the
+# box which appears at the bottom of the screen when you click on an event).
+# The {{host}} and {{service}} tags will be replaced by the those of the event.
+#
+# config.store[:pane_host_link] = 'http://dashboard.example.com/'
+# config.store[:pane_service_link] = 'http://dashboard/{{host}}/{{service}}/'

--- a/lib/riemann/dash/public/eventPane.js
+++ b/lib/riemann/dash/public/eventPane.js
@@ -5,8 +5,8 @@ var eventPane = (function() {
   var fixedFields = ['host', 'service', 'time', 'state', 'metric', 'ttl', 'description', 'tags'];
   var fixedTemplate =
     _.template(
-      '<div class="host">{{-host}}</div>' +
-      '<div class="service">{{-service}}</div>' +
+      '<div class="host"><a>{{-host}}</a></div>' +
+      '<div class="service"><a>{{-service}}</a></div>' +
       '<div class="state {{-state}}">{{-state}}</div>' +
       '<div class="metric">{{-metric}}</div>' +
       '<time class="absolute">{{-time}}</time>' +
@@ -53,6 +53,21 @@ var eventPane = (function() {
         table.append(rowTemplate({field: field, value: value}));
       }
     });
+
+    // Add href to <a> elements, if URLs are defined in configuration
+    var lmap = {
+      host: (event.host ? event.host : ''),
+      service: (event.service ? event.service : '')
+    }
+
+    if (typeof(pane_host_link) !== 'undefined') {
+      el.children('div.host').children('a').attr('href',
+        _.template(pane_host_link)(lmap));
+    }
+    if (typeof(pane_service_link) !== 'undefined') {
+      el.children('div.service').children('a').attr('href',
+        _.template(pane_service_link)(lmap));
+    }
   };
 
   // Hide on escape.

--- a/lib/riemann/dash/views/index.erubis
+++ b/lib/riemann/dash/views/index.erubis
@@ -37,6 +37,15 @@
   </script>
   <!-- end third party deps -->
 
+  <script> // transform eventPane config options into javascript variables
+<% if config.store[:pane_host_link] %>
+    var pane_host_link = "<%= config.store[:pane_host_link] %>"
+<% end %>
+<% if config.store[:pane_service_link] %>
+    var pane_service_link = "<%= config.store[:pane_service_link] %>"
+<% end %>
+  </script>
+
   <script src="util.js"></script>
   <script src="strings.js"></script>
   <script src="format.js"></script>


### PR DESCRIPTION
As suggested in my comment in #76.

To avoid having to define the URL in each and every view, I decided to make these global parameters of the dash. The downside is that there are ruby variables containing javascript templates, which are passed over to javascript in global variables, as part of a ruby template... A bit of a mess !

If you don't like this, I can confine it better by making these URLs configurable on a per-view basis (at the expense of having to configure them each time).