### PR TITLE
Drop default log lines from 1000 to 200

### DIFF
--- a/lib/riemann/dash/public/views/log.js
+++ b/lib/riemann/dash/public/views/log.js
@@ -5,7 +5,7 @@
       view.View.call(this, json);
       this.query = json.query;
       this.title = json.title;
-      this.lines = json.lines || 1000;
+      this.lines = json.lines || 200;
 
       var self = this;
 
@@ -126,4 +126,3 @@
       view.View.prototype.delete.call(this);
     };
 })();
-


### PR DESCRIPTION
On reasonably busy Riemann nodes, the log can fly by pretty fast. Having
a default of 1000 makes my browser crawl (and I don't have a wimpy
machine).