### PR TITLE
Let the y axis of flot chart extend to negative numbers.

### DIFF
--- a/lib/riemann/dash/public/views/flot.js
+++ b/lib/riemann/dash/public/views/flot.js
@@ -6,6 +6,7 @@
       this.query = json.query;
       this.title = json.title;
       this.max = json.max || null;
+      this.min = json.min || null;
       this.graphType = json.graphType || 'line';
       this.stackMode = json.stackMode || 'false';
       this.lineWidth = json.lineWidth || 1;
@@ -94,7 +95,7 @@
         },
         yaxis: {
           font: this.font,
-          min: 0,
+          min: this.min,
           max: this.max
         }, 
         xaxis: {
@@ -241,6 +242,7 @@
         type: 'Flot',
         title: this.title,
         query: this.query,
+        min: this.min,
         max: this.max,
         timeRange: this.timeRange / 1000,
         graphType: this.graphType,
@@ -266,6 +268,10 @@
       '<textarea type="text" class="query" name="query">{{ query }}</textarea><br />' +
       '<label for="timeRange">Time range (s)</label>' +
       '<input type="text" name="timeRange" value="{{timeRange / 1000}}" />' +
+      '<br />' +
+      '<label for="min">Min</label>' +
+      '<input type="text" name="min" value="{{min}}" />' +
+      '<br />' +
       '<label for="max">Max</label>' +
       '<input type="text" name="max" value="{{max}}" />'
     );


### PR DESCRIPTION
I'm using riemann to check if some metrics are roughly equal. For this task i'm using riemann-dash inspect the difference between these metrics, which can of course be negative.
The flot chart will not display negative values, it stops at 0. 

This pull request makes some small changes to the flot chart so the chart resizes its axis so negative numbers are displayed.
Setting 'min' to 0 gives the old behaviour. 
