### PR TITLE
Show status in Gauge if value is undefined

### DIFF
--- a/lib/riemann/dash/public/views/gauge.js
+++ b/lib/riemann/dash/public/views/gauge.js
@@ -37,7 +37,11 @@
         this.sub = subs.subscribe(this.query, function(e) {
           self.currentEvent = e;
           me.box.attr('class', 'box state ' + e.state);
-          value.text(format.float(e.metric, 2, me.commaSeparateThousands));
+          if (e.metric != undefined) {
+            value.text(format.float(e.metric, 2, me.commaSeparateThousands));
+          } else if (e.state != undefined) {
+            value.text(e.state)
+          }
           value.attr('title', e.description);
 
           // The first time, do a full-height reflow.


### PR DESCRIPTION
If the value in a Gauge is undefined, show the status, like Grid does.

The text for "critical" and "warning" gets cut off in some font sizes, not sure if this could be fixed in the CSS?
