### PR TITLE
Config can be specified with RIEMANN_DASH_CONFIG

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,11 @@ set :bind, "1.2.3.4" # Bind to a different interface
 config[:ws_config] = 'custom/config.json' # Specify custom workspace config
 ```
 
+You can also specify the default config file to be used by setting the
+`RIEMANN_DASH_CONFIG` environment variable. If set, this value will override
+the default config file location of `config.rb` when no config file is passed
+on the command line.
+
 Putting in production
 =====================
 

--- a/lib/riemann/dash/app.rb
+++ b/lib/riemann/dash/app.rb
@@ -17,7 +17,7 @@ module Riemann
       end
 
       def self.load(filename)
-        filename ||= 'config.rb'
+        filename ||= ENV['RIEMANN_DASH_CONFIG'] || 'config.rb'
         unless config.load_config(filename)
           # Configuration failed; load a default view.
           puts "No configuration loaded; using defaults."


### PR DESCRIPTION
If specified, `RIEMANN_DASH_CONFIG` will override the default value of `config.rb`